### PR TITLE
get_score(): correctly handle nonnumeric ID column

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -90,12 +90,12 @@ def upload_file():
 @login_required
 def get_score(filename, competition_id):
 
-    regex = r'(\d+),(\d+\.\d+|\d+)'
+    regex = r'(.+),(\d+\.\d+|\d+)'
 
     # parse files
-    predictions = np.fromregex(filename, regex, [('id', np.int32), ('v0', np.float32)])
+    predictions = np.fromregex(filename, regex, [('id', 'S128'), ('v0', np.float32)])
     groundtruth_filename = os.path.join(app.config['GROUNDTRUTH_FOLDER'], Competition.query.get(competition_id).groundtruth)
-    groundtruth = np.fromregex(groundtruth_filename, regex, [('id', np.int32), ('v0', np.float32)])
+    groundtruth = np.fromregex(groundtruth_filename, regex, [('id', 'S128'), ('v0', np.float32)])
 
     # sort data
     predictions.sort(order='id')


### PR DESCRIPTION
get_score() function was failing to correctly read the ID column if it didn't contain just numbers. For example "17f01126-5256-4dc7-bc10" would have been read as ID "10". This change makes the ID column more permissive - it loads general strings.