### PR TITLE
Restrict uploads to be 23h apart not 24h

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -58,7 +58,7 @@ def upload_file():
                 return redirect(request.url)
             
             # check if the user has made submissions in the past 24h
-            if Submission.query.filter_by(user_id=user_id).filter_by(competition_id=competition_id).filter(Submission.submitted_on>now-timedelta(days=1)).count() > 0:
+            if Submission.query.filter_by(user_id=user_id).filter_by(competition_id=competition_id).filter(Submission.submitted_on>now-timedelta(hours=23)).count() > 0:
                 flash("You already did a submission in the past 24h.")
                 return redirect(request.url)
 


### PR DESCRIPTION
This is to allow some slack. If we force competitors to be at least 24h apart, this causes difficulty because they would have to be precise in their timing, else they would be submitting at _lower_ than one per day.