### PR TITLE
scores view: allow graph to find its own minimum

### DIFF
--- a/app/templates/scores.html
+++ b/app/templates/scores.html
@@ -54,8 +54,7 @@ function plot_data(json) {
         vAxis: {
             viewWindowMode:'explicit',
             viewWindow: {
-                max:0,
-                min:100
+                max:100
             }
         },
         hAxis: {


### PR DESCRIPTION
Suggesting that we don't pin the minimum to 0. That way the scores (all over 50) are more inspectable