### PR TITLE
Prepend timestamp onto uploaded filenames

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -64,7 +64,8 @@ def upload_file():
 
             if file:
 
-                filename = secure_filename(file.filename)
+                filetimestamp = "%i%i%i%i%i" % now.timetuple()[:5]
+                filename = "%s%s" % (filetimestamp, secure_filename(file.filename))
                 filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
                 file.save(filepath)
                 


### PR DESCRIPTION
To ensure unique filenames.

At present `filename` is not unique. I see that one user has uploaded "fusion.csv" at least 3 times, and presumably the latest file overwrites, since they're going to the same folder? So this is a problem if we need to access those files.

This simple-minded fix puts the timestamp onto the start of the filename. (Neater would be to use the submission ID number, but that is not known until after the db commit.)